### PR TITLE
Adds support for Pest php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "league/flysystem": "^1.0",
         "mpociot/documentarian": "^0.4.0",
         "mpociot/reflection-docblock": "^1.0.1",
-        "nunomaduro/collision": "^3.0|^4.0",
+        "nunomaduro/collision": "^3.0|^4.0|^5.0",
         "ramsey/uuid": "^3.8|^4.0",
         "symfony/var-exporter": "^4.0|^5.0"
     },


### PR DESCRIPTION
This fix will expands the "nunomaudor/collision" package to support version ^5.0, since it's required in the testing framework Pest.